### PR TITLE
feat: Store selected branch ID in local storage during login

### DIFF
--- a/app/LoginStage.tsx
+++ b/app/LoginStage.tsx
@@ -9,8 +9,10 @@ import { WarningNotificationController } from "@/components/Notification";
 import { twMerge } from "tailwind-merge";
 import BranchesApi from "@/helpers/api/branches";
 import { Input } from "@/components/composition/Input";
+import LocalStorage from "@/helpers/storage";
 
 const usersApi = UsersApi.getInstance();
+const localStorage = LocalStorage.getInstance();
 
 type LoginStageProps = {
   onClick: (user: UserData) => void;
@@ -66,6 +68,10 @@ export default function LoginStage(props: LoginStageProps) {
   }, [fullname, cpf, email, whatsapp, gender, branchId, onClick]);
 
   useEffect(() => {
+    if(branchId) localStorage.setBranchId(branchId);
+  }, [branchId]);
+
+  useEffect(() => {
     //@ts-ignore
     window.onCurrentLocation = (latitude: number, longitude: number) => {
       // Make something with latitude and longitude
@@ -115,7 +121,9 @@ export default function LoginStage(props: LoginStageProps) {
       const branches = await BranchesApi.getInstance().getBranches();
 
       setBranches(branches);
-      setBranchId(branches[0].id);
+
+      const defaultBranchId = localStorage.getBranchId();
+      setBranchId(defaultBranchId || branches[0].id);
     };
 
     getLocation();

--- a/helpers/storage.ts
+++ b/helpers/storage.ts
@@ -10,6 +10,7 @@ export default class LocalStorage {
   // Address of data in local storage
   private readonly KEY_TOKEN = "TOKEN";
   private readonly KEY_CURRENT_LOCATION = "CURRENT_LOCATION";
+  private readonly KEY_BRANCH_ID = "BRANCH_ID";
 
   private constructor() {}
 
@@ -52,5 +53,19 @@ export default class LocalStorage {
     }
 
     return null;
+  }
+
+  public setBranchId(branchId: number) {
+    const { storage, KEY_BRANCH_ID } = this;
+
+    return storage().setItem(KEY_BRANCH_ID, branchId.toString());
+  }
+
+  public getBranchId(): Nullable<number> {
+    const { storage, KEY_BRANCH_ID } = this;
+
+    const branchIdString = storage().getItem(KEY_BRANCH_ID);
+
+    return branchIdString ? Number(branchIdString) : null;
   }
 }


### PR DESCRIPTION
This commit adds functionality to store the selected branch ID in local storage when the user logs in. It uses the `LocalStorage` helper class to set the branch ID and retrieve it later. This ensures that the selected branch remains persistent across page reloads or navigation within the application.